### PR TITLE
Prevent adding extra prefix

### DIFF
--- a/background.js
+++ b/background.js
@@ -46,7 +46,7 @@ function updateTab( tab, allTabs ) {
 	const num = index + 1
 	let newPrefix = num <= 8 ? `${num}. ` :
 					        num >= 9 && num === numTabs ? '9. ' :
-					        '-. '
+					        ''
 
 	const hasPrefix = prefixRegEx.exec( title )
 	if ( hasPrefix && hasPrefix[0] && hasPrefix[0] === newPrefix ) {


### PR DESCRIPTION
For any tabs that don't have a number it shows `-, ` in the title. It actually doesn't look good. Moreover, it takes up some space. Hence I am proposing to remove this.